### PR TITLE
chore: directly import dataclass

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,39 +1,38 @@
 """Provides NLP via spaCy and sense2vec over an HTTP API."""
 
 import os
-import typing
+from typing import List
 
-import fastapi
-import pydantic
-import sense2vec
 import spacy
-import starlette.responses
-import starlette.status
-
 from dataclasses import dataclass
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, root_validator
+from sense2vec import Sense2VecComponent
+from starlette.responses import Response
+from starlette.status import HTTP_204_NO_CONTENT
 
-app: fastapi.FastAPI = fastapi.FastAPI()
+app: FastAPI = FastAPI()
 model: str = os.getenv('SPACY_MODEL')
 pipeline_error: str = f"The model ({model}) doesn't support " + '{}.'
 nlp: spacy = spacy.load(model)
 if os.getenv('SENSE2VEC') == '1':
     nlp.add_pipe(
-        sense2vec.Sense2VecComponent(nlp.vocab).from_disk('src/s2v_old')
+        Sense2VecComponent(nlp.vocab).from_disk('src/s2v_old')
     )
 
 
-def enforce_components(components: typing.List[str], message: str) -> None:
+def enforce_components(components: List[str], message: str) -> None:
     """Throws the <message> if the model doesn't have the <components>."""
     for component in components:
         if not nlp.has_pipe(component):
-            raise fastapi.HTTPException(
+            raise HTTPException(
                 status_code=400,
                 detail=pipeline_error.format(message)
             )
 
 
-class NERRequest(pydantic.BaseModel):
-    sections: typing.List[str]
+class NERRequest(BaseModel):
+    sections: List[str]
     sense2vec: bool = False
 
 
@@ -47,18 +46,18 @@ class BuiltEntity:
     start: int
     end: int
     text_with_ws: str
-    sense2vec: typing.List[str]
+    sense2vec: List[str]
 
 
 @dataclass
 class SentenceWithEntities:
     text: str
-    entities: typing.List[BuiltEntity]
+    entities: List[BuiltEntity]
 
 
 @dataclass
 class NERResponse:
-    data: typing.List[SentenceWithEntities]
+    data: List[SentenceWithEntities]
 
 
 @app.post('/ner')
@@ -72,7 +71,7 @@ async def recognize_named_entities(request: NERRequest) -> NERResponse:
     response: NERResponse = NERResponse([])
     for doc in nlp.pipe(request.sections, disable=['tagger']):
         for sent in doc.sents:
-            entities: typing.List[BuiltEntity] = [
+            entities: List[BuiltEntity] = [
                 build_entity(ent, request.sense2vec) for ent in sent.ents
             ]
             data: SentenceWithEntities = SentenceWithEntities(
@@ -83,7 +82,7 @@ async def recognize_named_entities(request: NERRequest) -> NERResponse:
     return response
 
 
-class SimilarPhrase(pydantic.BaseModel):
+class SimilarPhrase(BaseModel):
     """Similar phrases computed by sense2vec."""
 
     """The similar phrase."""
@@ -92,13 +91,13 @@ class SimilarPhrase(pydantic.BaseModel):
     similarity: float
 
 
-def compute_phrases(ent) -> typing.List[SimilarPhrase]:
+def compute_phrases(ent) -> List[SimilarPhrase]:
     """Computes similar phrases for the entity (<ent>).
 
     The entity must have already been processed by the ner, parser, and
     sense2vec pipeline components.
     """
-    similar: typing.List[SimilarPhrase] = []
+    similar: List[SimilarPhrase] = []
     if ent._.in_s2v:
         for data in ent._.s2v_most_similar():
             similar.append(
@@ -121,13 +120,13 @@ def build_entity(ent: spacy, use_sense2vec: bool) -> BuiltEntity:
     )
 
 
-class PhraseInSentence(pydantic.BaseModel):
+class PhraseInSentence(BaseModel):
     """A <phrase> in a <sentence>."""
 
     sentence: str
     phrase: str
 
-    @pydantic.root_validator
+    @root_validator
     def phrase_must_be_in_sentence(cls, values):
         if values.get('phrase') not in values.get('sentence'):
             raise ValueError('phrase must be in sentence')
@@ -136,21 +135,21 @@ class PhraseInSentence(pydantic.BaseModel):
 
 @dataclass
 class Sense2vecResponse:
-    sense2vec: typing.List[SimilarPhrase]
+    sense2vec: List[SimilarPhrase]
 
 
 @app.post('/sense2vec')
 async def sense2vec(request: PhraseInSentence) -> Sense2vecResponse:
     enforce_components(['ner', 'parser', 'sense2vec'], 'sense2vec')
     doc: nlp = nlp(request.sentence, disable=['tagger'])
-    phrases: typing.List[SimilarPhrase] = []
+    phrases: List[SimilarPhrase] = []
     for ent in list(doc.sents)[0].ents:
         if ent.text == request.phrase:
-            phrases: typing.List[SimilarPhrase] = compute_phrases(ent)
+            phrases: List[SimilarPhrase] = compute_phrases(ent)
     return Sense2vecResponse(phrases)
 
 
-class TextModel(pydantic.BaseModel):
+class TextModel(BaseModel):
     text: str
 
 
@@ -198,12 +197,12 @@ class Token:
 @dataclass
 class TaggedText:
     text: str
-    tags: typing.List[Token]
+    tags: List[Token]
 
 
 @dataclass
 class POSResponse:
-    data: typing.List[TaggedText]
+    data: List[TaggedText]
 
 
 @dataclass
@@ -215,7 +214,7 @@ class TokenWithSentence:
 @app.post('/pos')
 async def tag_parts_of_speech(request: TextModel) -> POSResponse:
     enforce_components(['ner', 'parser', 'tagger'], 'part-of-speech tagging')
-    data: typing.List[TaggedText] = []
+    data: List[TaggedText] = []
     doc: nlp = nlp(request.text, disable=['sense2vec'])
     for token_with_sent in [build_token_with_sent(token) for token in doc]:
         if token_with_sent.sent in [obj.text for obj in data]:
@@ -277,7 +276,7 @@ def build_token_with_sent(token) -> TokenWithSentence:
 
 @dataclass
 class TokenizerResponse:
-    tokens: typing.List[str]
+    tokens: List[str]
 
 
 @app.post('/tokenizer')
@@ -291,7 +290,7 @@ async def tokenize(request: TextModel) -> TokenizerResponse:
 
 @dataclass
 class SentencizerResponse:
-    sentences: typing.List[str]
+    sentences: List[str]
 
 
 @app.post('/sentencizer')
@@ -302,7 +301,7 @@ async def sentencize(request: TextModel) -> SentencizerResponse:
 
 
 @app.get('/health_check')
-async def check_health() -> starlette.responses.Response:
-    return starlette.responses.Response(
-        status_code=starlette.status.HTTP_204_NO_CONTENT
+async def check_health() -> Response:
+    return Response(
+        status_code=HTTP_204_NO_CONTENT
     )

--- a/src/main.py
+++ b/src/main.py
@@ -3,13 +3,14 @@
 import os
 import typing
 
-import dataclasses
 import fastapi
 import pydantic
 import sense2vec
 import spacy
 import starlette.responses
 import starlette.status
+
+from dataclasses import dataclass
 
 app: fastapi.FastAPI = fastapi.FastAPI()
 model: str = os.getenv('SPACY_MODEL')
@@ -36,7 +37,7 @@ class NERRequest(pydantic.BaseModel):
     sense2vec: bool = False
 
 
-@dataclasses.dataclass
+@dataclass
 class BuiltEntity:
     text: str
     label: str
@@ -49,13 +50,13 @@ class BuiltEntity:
     sense2vec: typing.List[str]
 
 
-@dataclasses.dataclass
+@dataclass
 class SentenceWithEntities:
     text: str
     entities: typing.List[BuiltEntity]
 
 
-@dataclasses.dataclass
+@dataclass
 class NERResponse:
     data: typing.List[SentenceWithEntities]
 
@@ -133,7 +134,7 @@ class PhraseInSentence(pydantic.BaseModel):
         return values
 
 
-@dataclasses.dataclass
+@dataclass
 class Sense2vecResponse:
     sense2vec: typing.List[SimilarPhrase]
 
@@ -153,7 +154,7 @@ class TextModel(pydantic.BaseModel):
     text: str
 
 
-@dataclasses.dataclass
+@dataclass
 class Token:
     text: str
     text_with_ws: str
@@ -194,18 +195,18 @@ class Token:
     char_offset: int
 
 
-@dataclasses.dataclass
+@dataclass
 class TaggedText:
     text: str
     tags: typing.List[Token]
 
 
-@dataclasses.dataclass
+@dataclass
 class POSResponse:
     data: typing.List[TaggedText]
 
 
-@dataclasses.dataclass
+@dataclass
 class TokenWithSentence:
     token: Token
     sent: str
@@ -274,7 +275,7 @@ def build_token_with_sent(token) -> TokenWithSentence:
     )
 
 
-@dataclasses.dataclass
+@dataclass
 class TokenizerResponse:
     tokens: typing.List[str]
 
@@ -288,7 +289,7 @@ async def tokenize(request: TextModel) -> TokenizerResponse:
     return TokenizerResponse([token.text for token in doc])
 
 
-@dataclasses.dataclass
+@dataclass
 class SentencizerResponse:
     sentences: typing.List[str]
 

--- a/src/test_main.py
+++ b/src/test_main.py
@@ -1,19 +1,19 @@
 import json
 import re
-import typing
+from typing import List 
 
-import fastapi
-import main
-import pydantic
 import pytest
-import requests
-import starlette.testclient
+from fastapi import HTTPException
+from main import NERRequest, PhraseInSentence, TextModel, app, compute_phrases, enforce_components, nlp
+from pydantic import BaseModel
+from requests import Response
+from starlette.testclient import TestClient
 
-client: starlette.testclient.TestClient = starlette.testclient.TestClient(
-    main.app
+client: TestClient = TestClient(
+    app
 )
 
-ner_sections: typing.List[str] = [
+ner_sections: List[str] = [
     'Net income was $9.4 million compared to the prior year of $2.7 million. '
     + 'Google is a big company.',
     'Revenue exceeded twelve billion dollars, with a loss of $1b.'
@@ -21,9 +21,9 @@ ner_sections: typing.List[str] = [
 
 
 def test_ner_sense2vec_enabled() -> None:
-    response: requests.Response = client.post(
+    response: Response = client.post(
         '/ner',
-        json=dict(main.NERRequest(sections=ner_sections, sense2vec=True))
+        json=dict(NERRequest(sections=ner_sections, sense2vec=True))
     )
     assert response.status_code == 200
     with open('src/outputs/ner/sense2vec_enabled.json') as f:
@@ -31,44 +31,44 @@ def test_ner_sense2vec_enabled() -> None:
 
 
 def test_ner_sense2vec_disabled() -> None:
-    response: requests.Response = client.post(
+    response: Response = client.post(
         '/ner',
-        json=dict(main.NERRequest(sections=ner_sections))
+        json=dict(NERRequest(sections=ner_sections))
     )
     with open('src/outputs/ner/sense2vec_disabled.json') as f:
         assert response.json() == json.load(f)
 
 
 def test_ner_spacy_fail() -> None:
-    fail('/ner', main.NERRequest(sections=ner_sections), pipe='ner')
+    fail('/ner', NERRequest(sections=ner_sections), pipe='ner')
 
 
 def test_ner_sense2vec_fail() -> None:
     fail(
         '/ner',
-        main.NERRequest(sections=ner_sections, sense2vec=True),
+        NERRequest(sections=ner_sections, sense2vec=True),
         pipe='sense2vec'
     )
 
 
 def test_sense2vec_success() -> None:
-    body: main.PhraseInSentence = main.PhraseInSentence(
+    body: PhraseInSentence = PhraseInSentence(
         sentence='Bill Gates founded Microsoft in April 4, 1975.',
         phrase='Bill Gates'
     )
-    response: requests.Response = client.post('/sense2vec', json=dict(body))
+    response: Response = client.post('/sense2vec', json=dict(body))
     assert response.status_code == 200
     with open('src/outputs/sense2vec.json') as f:
         assert response.json() == json.load(f)
 
 
-pos_body: main.TextModel = main.TextModel(
+pos_body: TextModel = TextModel(
     text='Apple is looking at buying U.K. startup for $1 billion'
 )
 
 
 def test_pos() -> None:
-    response: requests.Response = client.post('/pos', json=dict(pos_body))
+    response: Response = client.post('/pos', json=dict(pos_body))
     assert response.status_code == 200
     with open('src/outputs/pos.json') as f:
         assert response.json() == json.load(f)
@@ -79,23 +79,23 @@ def test_pos_fail() -> None:
 
 
 def test_tokenizer() -> None:
-    text: main.TextModel = main.TextModel(
+    text: TextModel = TextModel(
         text='Apple is looking at buying U.K. startup for $1 billion'
     )
-    response: requests.Response = client.post('/tokenizer', json=dict(text))
+    response: Response = client.post('/tokenizer', json=dict(text))
     assert response.status_code == 200
     with open('src/outputs/tokenizer.json') as f:
         assert response.json() == json.load(f)
 
 
-sentencizer_body: main.TextModel = main.TextModel(
+sentencizer_body: TextModel = TextModel(
     text='Apple is looking at buying U.K. startup for $1 billion. Another '
          + 'sentence.'
 )
 
 
 def test_sentencizer() -> None:
-    response: requests.Response = client.post(
+    response: Response = client.post(
         '/sentencizer',
         json=dict(sentencizer_body)
     )
@@ -112,23 +112,23 @@ def test_health_check() -> None:
     assert client.get('/health_check').status_code == 204
 
 
-def fail(endpoint: str, body: pydantic.BaseModel, pipe: str) -> None:
-    with main.nlp.disable_pipes(pipe):
-        response: requests.Response = client.post(endpoint, json=dict(body))
+def fail(endpoint: str, body: BaseModel, pipe: str) -> None:
+    with nlp.disable_pipes(pipe):
+        response: Response = client.post(endpoint, json=dict(body))
         assert re.match(r'4\d\d', str(response.status_code))
         assert 'detail' in response.json()
 
 
 def test_enforce_components() -> None:
-    with pytest.raises(fastapi.HTTPException):
+    with pytest.raises(HTTPException):
         component: str = 'nonexistent_component'
-        main.enforce_components([component], component)
+        enforce_components([component], component)
 
 
 def test_compute_phrases() -> None:
     sentence: str = 'Bill Gates founded Microsoft in April 4, 1975.'
-    doc: main.nlp = main.nlp(sentence, disable=['tagger'])
+    doc: nlp = nlp(sentence, disable=['tagger'])
     for ent in list(doc.sents)[0].ents:
         if ent.text == 'Bill Gates':
             with open('src/outputs/compute_phrases.json') as f:
-                assert main.compute_phrases(ent) == json.load(f)
+                assert compute_phrases(ent) == json.load(f)


### PR DESCRIPTION
Closes #39.

Import `dataclass` directly instead of accessing it from `dataclasses`. Import statements are formatted using this user's suggestion from https://stackoverflow.com/a/20763446.